### PR TITLE
bunx for husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,3 @@
-npx lint-staged
+bunx --bun lint-staged
 
 bunx tsc --build .


### PR DESCRIPTION
### TL;DR

Updated pre-commit hook to use Bun for running lint-staged.

### What changed?

Modified the `.husky/pre-commit` file to replace `npx lint-staged` with `bunx --bun lint-staged`.

### Why make this change?

This change leverages Bun's faster execution speed for running lint-staged, potentially improving the performance of the pre-commit hook. Using Bun instead of Node.js for this task can lead to quicker commit processes, especially in larger projects with many files to lint.